### PR TITLE
fix(typescript): fallback to checking cjs/mjs on missing cts/mts

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -52,15 +52,15 @@ export const resolve: resolve = async function (
 	}
 
 	/**
-	 * Typescript 4.6.0 behavior seems to be that if `.mjs` is specified,
-	 * it converts it to mts without testing if it exists, and without
-	 * consideration for whether a file with .mjs exists
+	 * Typescript gives .mts or .cts priority over actual .mjs or .cjs extensions
 	 */
 	if (
 		/\.[cm]js$/.test(specifier)
 		&& tsExtensionsPattern.test(context.parentURL!)
 	) {
-		specifier = `${specifier.slice(0, -2)}ts`;
+		try {
+			return await resolve(`${specifier.slice(0, -2)}ts`, context, defaultResolve);
+		} catch {}
 	}
 
 	if (tsExtensionsPattern.test(specifier)) {

--- a/tests/specs/javascript/cjs.ts
+++ b/tests/specs/javascript/cjs.ts
@@ -30,6 +30,15 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 						expect(nodeProcess.stderr).toMatch('Cannot find module \'node:');
 					}
 				});
+
+				test('TypeScript Import', async () => {
+					const nodeProcess = await node.import(importPath, { typescript: true });
+					if (semver.satisfies(node.version, nodeSupportsNodePrefixRequire)) {
+						expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
+					} else {
+						expect(nodeProcess.stderr).toMatch('Cannot find module \'node:');
+					}
+				});
 			});
 
 			describe('extensionless - should not work', ({ test }) => {

--- a/tests/specs/javascript/esm.ts
+++ b/tests/specs/javascript/esm.ts
@@ -19,6 +19,11 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 					const nodeProcess = await node.import(importPath);
 					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
 				});
+
+				test('TypeScript Import', async () => {
+					const nodeProcess = await node.import(importPath, { typescript: true });
+					expect(nodeProcess.stdout).toBe(`${output}\n{"default":1234}`);
+				});
 			});
 
 			describe('extensionless - should not work', ({ test }) => {


### PR DESCRIPTION
## Problem
- When importing a `.mjs`/`.cjs` file from a TypeScript module, it didn't fallback to the `.mjs`/`.cjs` extension after failing to resolve the `.mts`/`.cts` version
- Reported in https://github.com/faker-js/faker/pull/960#issuecomment-1126942627

## Changes
- Try `.mts` or `.cts` first and fallback to original request
- Tests
