### PR TITLE
fix: stricter directory import

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -70,7 +70,7 @@ async function tryDirectory(
 	context: Context,
 	defaultResolve: resolve,
 ) {
-	const appendIndex = specifier.endsWith('/') ? 'index' : path.sep + 'index';
+	const appendIndex = specifier.endsWith('/') ? 'index' : `${path.sep}index`;
 
 	try {
 		return await tryExtensions(specifier + appendIndex, context, defaultResolve);

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -127,9 +127,7 @@ export const resolve: resolve = async function (
 				(error as any).code === 'ERR_MODULE_NOT_FOUND'
 				&& !hasExtensionPattern.test(specifier)
 			) {
-				try {
-					return await tryExtensions(specifier, context, defaultResolve);
-				} catch {}
+				return await tryExtensions(specifier, context, defaultResolve);
 			}
 		}
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import {
 	transform,
 	installSourceMapSupport,
@@ -69,7 +70,7 @@ async function tryDirectory(
 	context: Context,
 	defaultResolve: resolve,
 ) {
-	const appendIndex = specifier.endsWith('/') ? 'index' : '/index';
+	const appendIndex = specifier.endsWith('/') ? 'index' : path.sep + 'index';
 
 	try {
 		return await tryExtensions(specifier + appendIndex, context, defaultResolve);

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -23,22 +23,63 @@ type Resolved = {
 	format: ModuleFormat;
 };
 
+type Context = {
+	conditions: string[];
+	parentURL: string | undefined;
+};
+
 type resolve = (
 	specifier: string,
-	context: {
-		conditions: string[];
-		parentURL: string | undefined;
-	},
+	context: Context,
 	defaultResolve: resolve,
 ) => MaybePromise<Resolved>;
 
 const hasExtensionPattern = /\.\w+$/;
 
 const extensions = ['.js', '.json', '.ts', '.tsx', '.jsx'] as const;
-const possibleSuffixes = [
-	...extensions,
-	...extensions.map(extension => `/index${extension}` as const),
-];
+
+async function tryExtensions(
+	specifier: string,
+	context: Context,
+	defaultResolve: resolve,
+) {
+	let error;
+	for (const extension of extensions) {
+		try {
+			return await resolve(
+				specifier + extension,
+				context,
+				defaultResolve,
+			);
+		} catch (_error: any) {
+			if (error === undefined) {
+				const { message } = _error;
+				_error.message = _error.message.replace(`${extension}'`, "'");
+				_error.stack = _error.stack.replace(message, _error.message);
+				error = _error;
+			}
+		}
+	}
+
+	throw error;
+}
+
+async function tryDirectory(
+	specifier: string,
+	context: Context,
+	defaultResolve: resolve,
+) {
+	const appendIndex = specifier.endsWith('/') ? 'index' : '/index';
+
+	try {
+		return await tryExtensions(specifier + appendIndex, context, defaultResolve);
+	} catch (error: any) {
+		const { message } = error;
+		error.message = error.message.replace(`${appendIndex}'`, "'");
+		error.stack = error.stack.replace(message, error.message);
+		throw error;
+	}
+}
 
 export const resolve: resolve = async function (
 	specifier,
@@ -53,7 +94,7 @@ export const resolve: resolve = async function (
 
 	// If directory, can be index.js, index.ts, etc.
 	if (specifier.endsWith('/')) {
-		return resolve(`${specifier}index`, context, defaultResolve);
+		return await tryDirectory(specifier, context, defaultResolve);
 	}
 
 	/**
@@ -79,24 +120,16 @@ export const resolve: resolve = async function (
 	} catch (error) {
 		if (error instanceof Error) {
 			if ((error as any).code === 'ERR_UNSUPPORTED_DIR_IMPORT') {
-				return resolve(`${specifier}/index`, context, defaultResolve);
+				return await tryDirectory(specifier, context, defaultResolve);
 			}
 
 			if (
 				(error as any).code === 'ERR_MODULE_NOT_FOUND'
 				&& !hasExtensionPattern.test(specifier)
 			) {
-				for (const suffix of possibleSuffixes) {
-					try {
-						const trySpecifier = specifier + (
-							specifier.endsWith('/') && suffix.startsWith('/')
-								? suffix.slice(1)
-								: suffix
-						);
-
-						return await resolve(trySpecifier, context, defaultResolve);
-					} catch {}
-				}
+				try {
+					return await tryExtensions(specifier, context, defaultResolve);
+				} catch {}
 			}
 		}
 

--- a/tests/specs/typescript/cts.ts
+++ b/tests/specs/typescript/cts.ts
@@ -1,6 +1,8 @@
 import { testSuite, expect } from 'manten';
 import type { NodeApis } from '../../utils/node-with-loader';
 
+const isWin = process.platform === 'win32';
+
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.cts extension', ({ describe }) => {
 		describe('full path', ({ test }) => {
@@ -49,7 +51,11 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
-				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-cts/index\'');
+				expect(nodeProcess.stderr).toMatch(
+					isWin
+						? '\\lib\\ts-ext-cts\\index\''
+						: '/lib/ts-ext-cts/index\'',
+				);
 			});
 		});
 
@@ -64,7 +70,11 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
-				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-cts\'');
+				expect(nodeProcess.stderr).toMatch(
+					isWin
+						? '\\lib\\ts-ext-cts\''
+						: '/lib/ts-ext-cts\'',
+				);
 			});
 		});
 	});

--- a/tests/specs/typescript/cts.ts
+++ b/tests/specs/typescript/cts.ts
@@ -49,6 +49,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
+				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-cts/index\'');
 			});
 		});
 
@@ -63,6 +64,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
+				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-cts\'');
 			});
 		});
 	});

--- a/tests/specs/typescript/mts.ts
+++ b/tests/specs/typescript/mts.ts
@@ -49,7 +49,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				expect(nodeProcess.stderr).toMatch(
 					isWin
 						? '\\lib\\ts-ext-mts\\index\''
-						: '/lib/ts-ext-mts/index\''
+						: '/lib/ts-ext-mts/index\'',
 				);
 			});
 		});
@@ -68,7 +68,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				expect(nodeProcess.stderr).toMatch(
 					isWin
 						? '\\lib\\ts-ext-mts\''
-						: '/lib/ts-ext-mts/\''
+						: '/lib/ts-ext-mts/\'',
 				);
 			});
 		});

--- a/tests/specs/typescript/mts.ts
+++ b/tests/specs/typescript/mts.ts
@@ -67,7 +67,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
 				expect(nodeProcess.stderr).toMatch(
 					isWin
-						? '\\lib\\ts-ext-mts\''
+						? '\\lib\\ts-ext-mts\\\''
 						: '/lib/ts-ext-mts/\'',
 				);
 			});

--- a/tests/specs/typescript/mts.ts
+++ b/tests/specs/typescript/mts.ts
@@ -1,6 +1,8 @@
 import { testSuite, expect } from 'manten';
 import type { NodeApis } from '../../utils/node-with-loader';
 
+const isWin = process.platform === 'win32';
+
 export default testSuite(async ({ describe }, node: NodeApis) => {
 	describe('.mts extension', ({ describe }) => {
 		const output = 'loaded ts-ext-mts/index.mts true true true';
@@ -39,13 +41,16 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Load', async () => {
 				const nodeProcess = await node.load(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
-				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-mts/index\'');
 			});
 
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
-				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-mts/index\'');
+				expect(nodeProcess.stderr).toMatch(
+					isWin
+						? '\\lib\\ts-ext-mts\\index\''
+						: '/lib/ts-ext-mts/index\''
+				);
 			});
 		});
 
@@ -60,7 +65,11 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
-				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-mts/\'');
+				expect(nodeProcess.stderr).toMatch(
+					isWin
+						? '\\lib\\ts-ext-mts\''
+						: '/lib/ts-ext-mts/\''
+				);
 			});
 		});
 	});

--- a/tests/specs/typescript/mts.ts
+++ b/tests/specs/typescript/mts.ts
@@ -39,16 +39,18 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Load', async () => {
 				const nodeProcess = await node.load(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
+				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-mts/index\'');
 			});
 
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
+				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-mts/index\'');
 			});
 		});
 
 		describe('directory - should not work', ({ test }) => {
-			const importPath = './lib/ts-ext-mts';
+			const importPath = './lib/ts-ext-mts/';
 
 			test('Load', async () => {
 				const nodeProcess = await node.load(importPath);
@@ -58,6 +60,7 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			test('Import', async () => {
 				const nodeProcess = await node.import(importPath);
 				expect(nodeProcess.stderr).toMatch('Cannot find module');
+				expect(nodeProcess.stderr).toMatch('/lib/ts-ext-mts/\'');
 			});
 		});
 	});


### PR DESCRIPTION
## Problem
- Resolving directories initially tried to resolve `/index`. This would be problematic if the file actually existed because it is not CommonJS behavior.
- Error thrown on failed directory import was inaccurate

Closes https://github.com/esbuild-kit/esm-loader/issues/13

## Changes
- On directory import, directly import `index` file with extensions
- Edit error thrown to be contain accurate request path