### PR TITLE
feat: custom tsconfig path via ESBK_TSCONFIG_PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ The following properties are used from `tsconfig.json` in the working directory:
 - `jsxFactory`
 - `jsxFragmentFactory`
 
+### Custom `tsconfig.json`
+By default, `tsconfig.json` in CWD will be used for TypeScript-related configuration.
+
+To override, use:
+
+```sh
+ESBK_TSCONFIG_NAME=tsconfig.custom.json node --loader @esbuild/esm-loader ./file.ts
+```
+
 ### Cache
 Modules transformations are cached in the system cache directory ([`TMPDIR`](https://en.wikipedia.org/wiki/TMPDIR)). Transforms are cached by content hash so duplicate dependencies are not re-transformed.
 

--- a/README.md
+++ b/README.md
@@ -34,13 +34,13 @@ The following properties are used from `tsconfig.json` in the working directory:
 - `jsxFactory`
 - `jsxFragmentFactory`
 
-### Custom `tsconfig.json`
-By default, `tsconfig.json` in CWD will be used for TypeScript-related configuration.
+#### Custom `tsconfig.json` path
+By default, `tsconfig.json` will be detected from the current working directory.
 
-To override, use:
+To set a custom path, use the `ESBK_TSCONFIG_PATH` environment variable:
 
 ```sh
-ESBK_TSCONFIG_NAME=tsconfig.custom.json node --loader @esbuild/esm-loader ./file.ts
+ESBK_TSCONFIG_PATH=./path/to/tsconfig.custom.json node --loader @esbuild/esm-loader ./file.ts
 ```
 
 ### Cache

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	},
 	"dependencies": {
 		"@esbuild-kit/core-utils": "^2.0.0",
-		"get-tsconfig": "^4.0.5"
+		"get-tsconfig": "^4.1.0"
 	},
 	"devDependencies": {
 		"@pvtnbr/eslint-config": "^0.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   eslint: ^8.15.0
   execa: ^6.1.0
   get-node: ^13.0.1
-  get-tsconfig: ^4.0.5
+  get-tsconfig: ^4.1.0
   manten: ^0.1.0
   pkgroll: ^1.3.0
   semver: ^7.3.7
@@ -18,7 +18,7 @@ specifiers:
 
 dependencies:
   '@esbuild-kit/core-utils': 2.0.0
-  get-tsconfig: 4.0.5
+  get-tsconfig: 4.1.0
 
 devDependencies:
   '@pvtnbr/eslint-config': 0.22.0_4hx5bygx4rxgd7xwyndf6ymwce
@@ -2003,8 +2003,8 @@ packages:
       get-intrinsic: 1.1.1
     dev: true
 
-  /get-tsconfig/4.0.5:
-    resolution: {integrity: sha512-UiOHySG2zoM0krlrfJOMQoY5UR1Z57/HjMUJdi7lJHCLKiES9zZsDXtU0BPo2GUI5EqJmNRnqU3FdMjDmf2XaA==}
+  /get-tsconfig/4.1.0:
+    resolution: {integrity: sha512-bhshxJhpfmeQ8x4fAvDqJV2VfGp5TfHdLpmBpNZZhMoVyfIrOippBW4mayC3DT9Sxuhcyl56Efw61qL28hG4EQ==}
     dev: false
 
   /glob-parent/5.1.2:

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,7 +4,7 @@ import { getTsconfig, createPathsMatcher } from 'get-tsconfig';
 
 export const sourcemaps = installSourceMapSupport();
 
-const tsconfig = getTsconfig();
+const tsconfig = getTsconfig(undefined, process.env.ESBK_TSCONFIG_NAME);
 
 export const tsconfigRaw = tsconfig?.config;
 export const tsconfigPathsMatcher = tsconfig && createPathsMatcher(tsconfig);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,21 @@
 import path from 'path';
 import { installSourceMapSupport } from '@esbuild-kit/core-utils';
-import { getTsconfig, createPathsMatcher } from 'get-tsconfig';
+import {
+	getTsconfig,
+	parseTsconfig,
+	createPathsMatcher,
+} from 'get-tsconfig';
 
 export const sourcemaps = installSourceMapSupport();
 
-const tsconfig = getTsconfig(undefined, process.env.ESBK_TSCONFIG_NAME);
+const tsconfig = (
+	process.env.ESBK_TSCONFIG_PATH
+		? {
+			path: process.env.ESBK_TSCONFIG_PATH,
+			config: parseTsconfig(process.env.ESBK_TSCONFIG_PATH),
+		}
+		: getTsconfig()
+);
 
 export const tsconfigRaw = tsconfig?.config;
 export const tsconfigPathsMatcher = tsconfig && createPathsMatcher(tsconfig);

--- a/tests/fixtures/package-module/tsconfig/tsconfig-custom/tsconfig.custom-name.json
+++ b/tests/fixtures/package-module/tsconfig/tsconfig-custom/tsconfig.custom-name.json
@@ -1,5 +1,5 @@
 {
-	"extends": "./tsconfig.json",
+	"extends": "../tsconfig.json",
 	"compilerOptions": {
 		"jsxFactory": "console.error"
 	}

--- a/tests/fixtures/package-module/tsconfig/tsconfig.custom.json
+++ b/tests/fixtures/package-module/tsconfig/tsconfig.custom.json
@@ -1,0 +1,6 @@
+{
+	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"jsxFactory": "console.error"
+	}
+}

--- a/tests/specs/typescript/tsconfig.ts
+++ b/tests/specs/typescript/tsconfig.ts
@@ -10,6 +10,16 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			expect(nodeProcess.stdout).toBe('div null hello world\nnull null goodbye world');
 		});
 
+		test('supports ESBK_TSCONFIG_NAME', async () => {
+			const nodeProcess = await node.load('./src/tsx.tsx', {
+				cwd: './tsconfig',
+				env: {
+					ESBK_TSCONFIG_NAME: 'tsconfig.custom.json',
+				},
+			});
+			expect(nodeProcess.stderr).toMatch('div null hello world\nnull null goodbye world');
+		});
+
 		describe('paths', ({ test, describe }) => {
 			test('resolves baseUrl', async () => {
 				const nodeProcess = await node.load('./src/base-url.ts', {

--- a/tests/specs/typescript/tsconfig.ts
+++ b/tests/specs/typescript/tsconfig.ts
@@ -10,13 +10,14 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 			expect(nodeProcess.stdout).toBe('div null hello world\nnull null goodbye world');
 		});
 
-		test('supports ESBK_TSCONFIG_NAME', async () => {
+		test('Custom tsconfig.json path', async () => {
 			const nodeProcess = await node.load('./src/tsx.tsx', {
 				cwd: './tsconfig',
 				env: {
-					ESBK_TSCONFIG_NAME: 'tsconfig.custom.json',
+					ESBK_TSCONFIG_PATH: './tsconfig-custom/tsconfig.custom-name.json',
 				},
 			});
+			expect(nodeProcess.stdout).toBe('');
 			expect(nodeProcess.stderr).toMatch('div null hello world\nnull null goodbye world');
 		});
 

--- a/tests/utils/node-with-loader.ts
+++ b/tests/utils/node-with-loader.ts
@@ -7,6 +7,7 @@ type Options = {
 	args: string[];
 	nodePath: string;
 	cwd?: string;
+	env?: typeof process.env;
 	nodeOptions?: string[];
 };
 
@@ -20,6 +21,7 @@ export const nodeWithLoader = (
 	{
 		env: {
 			ESBK_DISABLE_CACHE: '1',
+			...options.env,
 		},
 		nodeOptions: [
 			...(options.nodeOptions ?? []),
@@ -47,6 +49,7 @@ export async function createNode(
 			filePath: string,
 			options?: {
 				cwd?: string;
+				env?: typeof process.env;
 				nodeOptions?: string[];
 			},
 		) {
@@ -55,6 +58,7 @@ export async function createNode(
 					args: [filePath],
 					nodePath: node.path,
 					cwd: path.join(fixturePath, options?.cwd ?? ''),
+					env: options?.env,
 					nodeOptions: options?.nodeOptions,
 				},
 			);

--- a/tests/utils/node-with-loader.ts
+++ b/tests/utils/node-with-loader.ts
@@ -7,7 +7,7 @@ type Options = {
 	args: string[];
 	nodePath: string;
 	cwd?: string;
-	env?: typeof process.env;
+	env?: NodeJS.ProcessEnv;
 	nodeOptions?: string[];
 };
 


### PR DESCRIPTION
# Summary

This PR adds support for `ESBK_TSCONFIG_NAME=tsconfig.custom.json` and passes it down to `get-tsconfig`.

(This will be used for the upcoming `tsx --tsconfig` arg)