### PR TITLE
test: resolve js to ts in aliased path

### DIFF
--- a/tests/fixtures/package-module/tsconfig/src/paths-prefix-match-js.ts
+++ b/tests/fixtures/package-module/tsconfig/src/paths-prefix-match-js.ts
@@ -1,0 +1,3 @@
+import value from 'p/nested-resolve-target.js';
+
+console.log(value);

--- a/tests/specs/typescript/tsconfig.ts
+++ b/tests/specs/typescript/tsconfig.ts
@@ -50,6 +50,13 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 				expect(nodeProcess.stdout).toBe('nested-resolve-target');
 			});
 
+			test('resolves paths via .js', async () => {
+				const nodeProcess = await node.load('./src/paths-prefix-match-js.ts', {
+					cwd: './tsconfig',
+				});
+				expect(nodeProcess.stdout).toBe('nested-resolve-target');
+			});
+
 			describe('dependency', ({ test }) => {
 				test('resolve current directory', async () => {
 					const nodeProcess = await node.load('./dependency-resolve-current-directory', {


### PR DESCRIPTION
Related: https://github.com/esbuild-kit/cjs-loader/pull/17

@schummar Seems this works in esm-loader