### PR TITLE
feat: project references

### DIFF
--- a/src/loaders-deprecated.ts
+++ b/src/loaders-deprecated.ts
@@ -12,7 +12,7 @@ import {
 import type { TransformOptions } from 'esbuild';
 import {
 	applySourceMap,
-	fileMatcher,
+	projectsMap,
 	tsExtensionsPattern,
 	getFormatFromFileUrl,
 	fileProtocol,
@@ -82,11 +82,18 @@ const _transformSource: transformSource = async function (
 		url.endsWith('.json')
 		|| tsExtensionsPattern.test(url)
 	) {
+		let tsconfigRaw: TransformOptions['tsconfigRaw'];
+		for (const project of projectsMap.values()) {
+			tsconfigRaw = project.fileMatcher(filePath) as TransformOptions['tsconfigRaw'];
+			if (tsconfigRaw) {
+				break;
+			}
+		}
 		const transformed = await transform(
 			source.toString(),
 			filePath,
 			{
-				tsconfigRaw: fileMatcher?.(filePath) as TransformOptions['tsconfigRaw'],
+				tsconfigRaw,
 			},
 		);
 

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -250,7 +250,7 @@ export const load: load = async function (
 		for (const project of projectsMap.values()) {
 			tsconfigRaw = project.fileMatcher(filePath) as TransformOptions['tsconfigRaw'];
 			if (tsconfigRaw) {
-				console.log({ tsconfigRaw: JSON.stringify(tsconfigRaw) });
+				console.log({ tsconfigRaw: project.tsconfig?.path });
 				break;
 			}
 		}

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -126,9 +126,7 @@ export const resolve: resolve = async function (
 		projectsMap.forEach((project) => {
 			if (project.tsconfigPathsMatcher) {
 				const possibleProjectPaths = project.tsconfigPathsMatcher(specifier);
-				if (possibleProjectPaths) {
-					possiblePaths.push(...possibleProjectPaths);
-				}
+				possiblePaths.push(...possibleProjectPaths);
 			}
 		});
 		for (const possiblePath of possiblePaths) {
@@ -138,6 +136,7 @@ export const resolve: resolve = async function (
 					context,
 					defaultResolve,
 				);
+				console.log(`Resolved from ESM: ${specifier} -> ${resolved.url}`);
 				return resolved;
 			} catch { }
 		}
@@ -184,7 +183,6 @@ export const resolve: resolve = async function (
 
 			if (code === 'ERR_MODULE_NOT_FOUND') {
 				try {
-					console.log(`Trying extensions for ${specifier}`);
 					return await tryExtensions(specifier, context, defaultResolve);
 				} catch { }
 			}

--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -100,7 +100,6 @@ export const resolve: resolve = async function (
 	defaultResolve,
 	recursiveCall,
 ) {
-	console.log(`Resolve from ESM: ${specifier}`);
 	// Added in v12.20.0
 	// https://nodejs.org/api/esm.html#esm_node_imports
 	if (!supportsNodePrefix && specifier.startsWith('node:')) {
@@ -117,6 +116,7 @@ export const resolve: resolve = async function (
 		|| isPathPattern.test(specifier)
 	);
 
+	// Possibly a tsconfig path
 	if (
 		projectsMap.size > 0
 		&& !isPath // bare specifier
@@ -129,6 +129,7 @@ export const resolve: resolve = async function (
 				possiblePaths.push(...possibleProjectPaths);
 			}
 		});
+
 		for (const possiblePath of possiblePaths) {
 			try {
 				const resolved = await resolve(
@@ -136,7 +137,7 @@ export const resolve: resolve = async function (
 					context,
 					defaultResolve,
 				);
-				console.log(`Resolved from ESM: ${specifier} -> ${resolved.url}`);
+
 				return resolved;
 			} catch { }
 		}
@@ -149,7 +150,7 @@ export const resolve: resolve = async function (
 		const tsPath = resolveTsPath(specifier);
 		if (tsPath) {
 			try {
-				await resolve(tsPath, context, defaultResolve, true);
+				return await resolve(tsPath, context, defaultResolve, true);
 			} catch (error) {
 				const { code } = error as any;
 				if (
@@ -218,7 +219,6 @@ export const load: load = async function (
 	context,
 	defaultLoad,
 ) {
-	console.log(`Load from ESM: ${url}`);
 	if (process.send) {
 		process.send({
 			type: 'dependency',
@@ -250,7 +250,6 @@ export const load: load = async function (
 		for (const project of projectsMap.values()) {
 			tsconfigRaw = project.fileMatcher(filePath) as TransformOptions['tsconfigRaw'];
 			if (tsconfigRaw) {
-				console.log({ tsconfigRaw: project.tsconfig?.path });
 				break;
 			}
 		}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import fs from 'fs';
 import { installSourceMapSupport } from '@esbuild-kit/core-utils';
 import {
 	getTsconfig,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,7 @@ function getProjectsMap(tsconfigPath?: string, projectsMap?: Map<string, {
 		return projectsMap;
 	}
 
-	if (!projectsMap.has(tsconfig.path)) {
+	if (projectsMap.has(tsconfig.path)) {
 		return projectsMap;
 	}
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,9 +36,7 @@ function getProjectsMap(tsconfigPath?: string, projectsMap?: Map<string, {
 		return projectsMap;
 	}
 
-	const packageName = JSON.parse(fs.readFileSync(path.join(path.dirname(tsconfig.path), 'package.json'), 'utf8')).name as string;
-
-	projectsMap.set(packageName, {
+	projectsMap.set(tsconfig.path, {
 		tsconfig,
 		tsconfigPathsMatcher: tsconfig && createPathsMatcher(tsconfig),
 		fileMatcher: tsconfig && createFilesMatcher(tsconfig),

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,6 +36,10 @@ function getProjectsMap(tsconfigPath?: string, projectsMap?: Map<string, {
 		return projectsMap;
 	}
 
+	if (!projectsMap.has(tsconfig.path)) {
+		return projectsMap;
+	}
+
 	projectsMap.set(tsconfig.path, {
 		tsconfig,
 		tsconfigPathsMatcher: tsconfig && createPathsMatcher(tsconfig),

--- a/tests/fixtures/package-module/tsconfig/dependency-resolve-project-reference.ts
+++ b/tests/fixtures/package-module/tsconfig/dependency-resolve-project-reference.ts
@@ -1,0 +1,3 @@
+import { resolve } from "resolve-project-reference";
+
+console.log(resolve);

--- a/tests/fixtures/package-module/tsconfig/node_modules/project-reference/tsconfig.json
+++ b/tests/fixtures/package-module/tsconfig/node_modules/project-reference/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": "../resolve-project-reference",
+    "paths": {
+      "~/*": [
+        "../resolve-project-reference/src/*"
+      ],
+    },
+  },
+}

--- a/tests/fixtures/package-module/tsconfig/resolve-project-reference/package.json
+++ b/tests/fixtures/package-module/tsconfig/resolve-project-reference/package.json
@@ -1,0 +1,4 @@
+{
+  "type": "module",
+  "main": "src/index.ts"
+}

--- a/tests/fixtures/package-module/tsconfig/resolve-project-reference/src/index.ts
+++ b/tests/fixtures/package-module/tsconfig/resolve-project-reference/src/index.ts
@@ -1,0 +1,1 @@
+export * from "~/resolve";

--- a/tests/fixtures/package-module/tsconfig/resolve-project-reference/src/resolve.ts
+++ b/tests/fixtures/package-module/tsconfig/resolve-project-reference/src/resolve.ts
@@ -1,0 +1,1 @@
+export const resolve = "resolved";

--- a/tests/fixtures/package-module/tsconfig/resolve-project-reference/tsconfig.json
+++ b/tests/fixtures/package-module/tsconfig/resolve-project-reference/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "baseUrl": ".",
+    "paths": {
+      "~/*": [
+        "src/*",
+      ],
+    },
+  },
+}

--- a/tests/fixtures/package-module/tsconfig/tsconfig.json
+++ b/tests/fixtures/package-module/tsconfig/tsconfig.json
@@ -5,9 +5,23 @@
 		"jsxFragmentFactory": "null",
 		"baseUrl": "./src",
 		"paths": {
-			"paths-exact-match": ["resolve-target"],
-			"p/*": ["utils/*"],
-			"*/s": ["utils/*"]
+			"paths-exact-match": [
+				"resolve-target"
+			],
+			"p/*": [
+				"utils/*"
+			],
+			"*/s": [
+				"utils/*"
+			],
+			"resolve-project-reference": [
+				"../resolve-project-reference/src/index.ts"
+			]
 		},
 	},
+	"references": [
+		{
+			"path": "./resolve-project-reference"
+		}
+	]
 }

--- a/tests/index.ts
+++ b/tests/index.ts
@@ -2,18 +2,19 @@ import { describe } from 'manten';
 import { createNode } from './utils/node-with-loader.js';
 
 const nodeVersions = [
-	'12.20.0', // CJS named export detection added
-	'12.22.11',
-	...(
-		process.env.CI
-			? [
-				'14.21.1',
-				'16.18.1',
-				'17.9.1',
-				'18.12.1',
-			]
-			: []
-	),
+	// '12.20.0', // CJS named export detection added
+	// '12.22.11',
+	// ...(
+	// 	process.env.CI
+	// 		? [
+	// 			'14.21.1',
+	// 			'16.18.1',
+	// 			'17.9.1',
+	// 			'18.12.1',
+	// 		]
+	// 		: []
+	// ),
+	'18.12.1',
 ];
 
 (async () => {

--- a/tests/specs/typescript/tsconfig.ts
+++ b/tests/specs/typescript/tsconfig.ts
@@ -147,6 +147,13 @@ export default testSuite(async ({ describe }, node: NodeApis) => {
 					});
 					expect(nodeProcess.stdout).toBe('resolved');
 				});
+
+				test('should resolve project reference', async () => {
+					const nodeProcess = await node.load('./dependency-resolve-project-reference', {
+						cwd: './tsconfig',
+					});
+					expect(nodeProcess.stdout).toBe('resolved');
+				});
 			});
 		});
 	});


### PR DESCRIPTION
Fixes https://github.com/esbuild-kit/tsx/issues/96 for `esm-loader`.

I'm walking through the `references` key in the first `tsconfig` and constructing a map of projects.

The alias paths are then tested against all projects until we get a winner.

We also apply the right `tsconfig` file in `transform`.

I added a test case to show that it works. ✅ 