### PR TITLE
fixes#61, fixes esbuild-kit/tsx#135: Remove preexisting extensions when trying extensions

### DIFF
--- a/src/loaders.ts
+++ b/src/loaders.ts
@@ -96,12 +96,17 @@ async function tryExtensions(
 	defaultResolve: NextResolve,
 ) {
 	const [specifierWithoutQuery, query] = specifier.split('?');
+	let specifierWithoutExtension = specifierWithoutQuery;
+	const fileExtension = path.extname(specifierWithoutQuery);
+	if (extensions.find(e => e === fileExtension)) {
+	  specifierWithoutExtension = specifierWithoutQuery.slice(0, fileExtension.length * -1);
+	}
 	let throwError: Error | undefined;
 	for (const extension of extensions) {
 		try {
 			return await resolveExplicitPath(
 				defaultResolve,
-				specifierWithoutQuery + extension + (query ? `?${query}` : ''),
+				specifierWithoutExtension + extension + (query ? `?${query}` : ''),
 				context,
 			);
 		} catch (_error) {


### PR DESCRIPTION
When attempting to resolve file extensions we should remove preexisting extensions.
This resolves importing a typescript file into a javascript file while using a `.js` extensions. This matches ts-node behavior and follows typescript guidance to import typescript files with the `.js` extension.